### PR TITLE
DEV-6915 #time 10m Rails 6.1 removes SchemaCreation class from Abstra…

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Redshift
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < SchemaCreation
         private
 
         def visit_ColumnDefinition(o)


### PR DESCRIPTION
…ctAdapter module; update to be compatible.