### PR TITLE
Dev 7136

### DIFF
--- a/activerecord6-redshift-adapter.gemspec
+++ b/activerecord6-redshift-adapter.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'activerecord6-redshift-adapter'
-  s.version = '1.2.0'
+  s.version = '1.2.1'
   s.summary = 'Amazon Redshift adapter for ActiveRecord '
   s.description = 'Amazon Redshift _makeshift_ adapter for ActiveRecord 6.'
   s.license = 'MIT'
 
-  s.author = ['Nancy Foen', 'Minero Aoki', 'iamdbc', 'Quentin Rousseau']
+  s.author = ['Nancy Foen', 'Minero Aoki', 'iamdbc', 'Quentin Rousseau', 'vmeow']
   s.email = 'fantast.d@gmail.com'
-  s.homepage = 'https://github.com/kwent/activerecord6-redshift-adapter'
+  s.homepage = 'https://github.com/ValorWaterAnalytics/activerecord6-redshift-adapter'
 
   s.files = Dir.glob(['LICENSE', 'README.md', 'lib/**/*.rb'])
   s.require_path = 'lib'

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -46,7 +46,7 @@ module ActiveRecord
         end
       end
 
-      class ColumnDefinition = Struct.new(:name, :type, :options, :sql_type) do
+      ColumnDefinition = Struct.new(:name, :type, :options, :sql_type) do
         def primary_key?
           options[:primary_key]
         end

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -30,23 +30,23 @@ module ActiveRecord
         # require you to assure that you always provide a UUID value before saving
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
-        def primary_key(name, type = :primary_key, options = {})
+        def primary_key(name, type = :primary_key, **options)
           return super unless type == :uuid
           options[:default] = options.fetch(:default, 'uuid_generate_v4()')
           options[:primary_key] = true
           column name, type, options
         end
 
-        def json(name, options = {})
+        def json(name, **options)
           column(name, :json, options)
         end
 
-        def jsonb(name, options = {})
+        def jsonb(name, **options)
           column(name, :jsonb, options)
         end
       end
 
-      class ColumnDefinition < Struct.new(:name, :type, :options, :sql_type)
+      class ColumnDefinition = Struct.new(:name, :type, :options, :sql_type) do
         def primary_key?
           options[:primary_key]
         end
@@ -56,6 +56,7 @@ module ActiveRecord
             def #{option_name}
               options[:#{option_name}]
             end
+
             def #{option_name}=(value)
               options[:#{option_name}] = value
             end
@@ -68,8 +69,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(*args)
-          Redshift::ColumnDefinition.new(*args)
+        def create_column_definition(name, type, options)
+          Redshift::ColumnDefinition.new(name, type, options)
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -5,7 +5,10 @@ module ActiveRecord
         private
 
         def visit_ColumnDefinition(o)
-          super
+          o.sql_type = type_to_sql(o.type, **o.options)
+          column_sql = +"#{quote_column_name(o.name)} #{o.sql_type}"
+          add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
+          column_sql
         end
 
         def add_column_options!(sql, options)
@@ -426,7 +429,7 @@ module ActiveRecord
         # Maps logical Rails types to PostgreSQL-specific data types.
         def type_to_sql(type, limit: nil, precision: nil, scale: nil, **)
           case type.to_s
-          when 'integer'
+          when 'integer', 'int'
             return 'integer' unless limit
 
             case limit

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -429,6 +429,10 @@ module ActiveRecord
         # Maps logical Rails types to PostgreSQL-specific data types.
         def type_to_sql(type, limit: nil, precision: nil, scale: nil, **)
           case type.to_s
+          when 'smallint'
+            return 'smallint'
+          when 'bigint'
+            return 'bigint'
           when 'integer', 'int'
             return 'integer' unless limit
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -168,7 +168,7 @@ module ActiveRecord
           super
         end
 
-        def drop_table(table_name, options = {})
+        def drop_table(table_name, **options)
            execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
         end
 
@@ -252,7 +252,7 @@ module ActiveRecord
         end
 
         # Drops the schema for the given schema name.
-        def drop_schema(schema_name, options = {})
+        def drop_schema(schema_name, **options)
           execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)} CASCADE"
         end
 
@@ -320,13 +320,13 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
         end
 
-        def add_column(table_name, column_name, type, options = {}) #:nodoc:
+        def add_column(table_name, column_name, type, **options) #:nodoc:
           clear_cache!
           super
         end
 
         # Changes the column of a table.
-        def change_column(table_name, column_name, type, options = {})
+        def change_column(table_name, column_name, type, **options)
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
           sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
@@ -373,7 +373,7 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
         end
 
-        def add_index(table_name, column_name, options = {}) #:nodoc:
+        def add_index(table_name, column_name, **options) #:nodoc:
         end
 
         def remove_index!(table_name, index_name) #:nodoc:

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -78,10 +78,10 @@ module ActiveRecord
         string:      { name: "varchar" },
         text:        { name: "varchar" },
         varchar:     { name: "varchar" },
-        smallint:    { name: "smallint" },
-        int:         { name: "integer" },
-        integer:     { name: "integer" },
-        bigint:      { name: "bigint" },
+        smallint:    { name: "smallint", limit: 2 },
+        int:         { name: "integer", limit: 4 },
+        integer:     { name: "integer", limit: 4 },
+        bigint:      { name: "bigint", limit: 8 },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "timestamp" },
@@ -89,8 +89,8 @@ module ActiveRecord
         time:        { name: "time" },
         date:        { name: "date" },
         boolean:     { name: "boolean" },
-        serial:      { name: "integer" },
-        bigserial:   { name: "bigint" },
+        serial:      { name: "integer", limit: 4 },
+        bigserial:   { name: "bigint", limit: 8 },
       }
 
       OID = Redshift::OID #:nodoc:

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -77,13 +77,17 @@ module ActiveRecord
         primary_key: "bigint identity primary key",
         string:      { name: "varchar" },
         text:        { name: "varchar" },
+        varchar:     { name: "varchar" },
+        smallint:    { name: "smallint" },
+        int:         { name: "integer" },
         integer:     { name: "integer" },
+        bigint:      { name: "bigint" },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "timestamp" },
+        timestamptz: { name: "timestamptz" },
         time:        { name: "time" },
         date:        { name: "date" },
-        bigint:      { name: "bigint" },
         boolean:     { name: "boolean" },
         serial:      { name: "integer" },
         bigserial:   { name: "bigint" },
@@ -350,10 +354,10 @@ module ActiveRecord
           }
         end
 
-        def initialize_type_map(m) # :nodoc:
-          register_class_with_limit m, 'int2', Type::Integer
-          register_class_with_limit m, 'int4', Type::Integer
-          register_class_with_limit m, 'int8', Type::Integer
+        def initialize_type_map(m = type_map) # :nodoc:
+          m.register_type "int2", Type::Integer.new(limit: 2)
+          m.register_type "int4", Type::Integer.new(limit: 4)
+          m.register_type "int8", Type::Integer.new(limit: 8)
           m.alias_type 'oid', 'int2'
           m.register_type 'float4', Type::Float.new
           m.alias_type 'float8', 'float4'

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -733,8 +733,8 @@ module ActiveRecord
           coder_class.new(oid: row["oid"].to_i, name: row["typname"])
         end
 
-        def create_table_definition(*args) # :nodoc:
-          Redshift::TableDefinition.new(self, *args)
+        def create_table_definition(name, **options) # :nodoc:
+          Redshift::TableDefinition.new(self, name, **options)
         end
     end
   end


### PR DESCRIPTION
fixes #5 

After running the linked migration from the issue:
```
class AddMockLimitColumnToDataSet < ActiveRecord::Migration[6.1]
  def change
    add_column :data_sets, :mock_limit_int_two, :int, limit: 2
    add_column :data_sets, :mock_limit_smallint, :smallint
    add_column :data_sets, :mock_limit_int_eight, :int, limit: 8
    add_column :data_sets, :mock_limit_bigint, :bigint
    add_column :data_sets, :mock_limit_varchar, :varchar, limit: 128
  end
end

```

The correct column types are created.
```
redshift=> \d data_sets
                                               Table "public.data_sets"
          Column          |            Type             | Collation | Nullable |               Default                
--------------------------+-----------------------------+-----------+----------+--------------------------------------
 id                       | integer                     |           | not null | "identity"(22371852, 0, '1,1'::text)
 mock_limit_int_two       | smallint                    |           |          | 
 mock_limit_smallint      | smallint                    |           |          | 
 mock_limit_int_eight     | bigint                      |           |          | 
 mock_limit_bigint        | bigint                      |           |          | 
 mock_limit_varchar       | character varying(128)      |           |          | 
```